### PR TITLE
Fix rllab dockerfile before migration to garage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM ubuntu:16.04
 # https://github.com/ContinuumIO/docker-images/blob/master/anaconda/Dockerfile
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
+SHELL ["/bin/bash", "-c"]
+
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git mercurial subversion
@@ -15,8 +17,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     rm ~/anaconda.sh
 
 RUN apt-get install -y curl grep sed dpkg && \
-    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
-    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    TINI_VERSION=`curl https://api.github.com/repos/krallin/tini/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini_${TINI_VERSION:1}.deb" > tini.deb && \
     dpkg -i tini.deb && \
     rm tini.deb && \
     apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,3 +89,4 @@ RUN MUJOCO_ZIP="mjpro$(echo ${MUJOCO_VERSION} | sed -e "s/\.//g")_linux.zip" \
 # ========== Package Patches ==========
 
 RUN source activate sql && pip install "numpy>=1.16"
+RUN sed -i 's/MemmapingPool/MemmappingPool/g' /root/rllab/rllab/sampler/stateful_pool.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN pip install Pillow
 WORKDIR /root/sql
 
 ADD environment.yml /root/sql/environment.yml
+RUN pip install --upgrade requests
 RUN conda env create -f /root/sql/environment.yml \
     && conda env update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN pip install awscli
 # ALE requires zlib
 RUN apt-get -y install zlib1g-dev
 # MUJOCO requires graphics stuff (Why?)
+RUN cp /etc/apt/sources.list /etc/apt/sources.list~ \
+    && sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list \
+    && apt-get update
 RUN apt-get -y build-dep glfw
 RUN apt-get -y install libxrandr2 libxinerama-dev libxi6 libxcursor-dev
 RUN apt-get install -y vim ack-grep

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,3 +85,7 @@ RUN MUJOCO_ZIP="mjpro$(echo ${MUJOCO_VERSION} | sed -e "s/\.//g")_linux.zip" \
     && cp ${MUJOCO_PATH}/mjpro131/bin/libmujoco131.so ${RLLAB_PATH}/vendor/mujoco/ \
     && cp ${MUJOCO_PATH}/mjpro131/bin/libglfw.so.3 ${RLLAB_PATH}/vendor/mujoco/ \
     && rm ${MUJOCO_PATH}/${MUJOCO_ZIP}
+
+# ========== Package Patches ==========
+
+RUN source activate sql && pip install "numpy>=1.16"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Currently, rendering of simulations is not supported on Docker due to a missing 
 export MUJOCO_LICENSE_PATH=<path_to_mujoco>/mjkey.txt
 ```
 
+Please note that you should not use relative paths such as `~/mujoco/mjkey.txt` in the environment variable, as Docker compose does not expand them. You could use `"$HOME/.mujoco/mjkey.txt"` instead.
+
 Once that's done, you can run the Docker container with
 
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
     - theano==0.8.2
     - pip:
         - gtimer
+        - protobuf==3.19.6
         - gym==0.8
         - mujoco_py==0.5.7
         - pyprind


### PR DESCRIPTION
This PR resolves issues about running the provided code in Docker with rllab.

The migration from rllab to garage appears to overlook Docker usages, thus it may be harder to fix.

I have fixed some of the docker issues regarding the migration to garage in another branch ([the `fix-garage` branch](https://github.com/j3soon/haarnoja-softqlearning/tree/fix-garage)). If I somehow managed to fix all issues, I'll open another PR for it.

I'll leave this as a draft for now, making it a potential reference for other docker users.
